### PR TITLE
 feat(style): sticky and blur effect for header

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -303,6 +303,12 @@ a:disabled,
   position: sticky;
 }
 
+header{
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
 .nav {
   position: relative;
   top: 0;
@@ -312,7 +318,21 @@ a:disabled,
   min-width: 1024px;
   z-index: 9997;
   height: 3.05882rem;
-  border-bottom: 1px solid var(--footer-background);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+.nav::after{
+  position: absolute;
+  content: " ";
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(255,255,255,0.7);
+}
+
+.theme-dark .nav::after {
+  background: rgba(29,29,31,0.7);
 }
 
 .nav-title {


### PR DESCRIPTION
为header部分添加了固定定位和磨砂效果背景，尽可能还原官方效果 XD

add sticky and blur effect for header, not exatly same as the official's 

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/16473062/225901625-e67c7d22-98f9-4376-9a89-6352f9a1537b.png">
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/16473062/225901556-10af6efd-a70a-4fbc-9bc0-4c86b92dcea8.png">