### PR TITLE
 Fix image missing on post page when using absolute image path

### DIFF
--- a/public/static/js/initPost.js
+++ b/public/static/js/initPost.js
@@ -45,7 +45,18 @@ function initLazyLoad() {
       let grandSon = item.firstChild.firstChild;
       let img = new Image();
       img.src = grandSon.src;
+
       let sign = md5(grandSon.src);
+
+      let target = document.getElementById(`lht${sign}`)
+      if (!target)  {
+          // If an absolute path is used as the image link, such as "/static/img.png",
+          // the URL of grandSon.src will become "https://example.com/static/img.png", resulting in a different md5.
+          // Therefore, we attempt to handle this situation by trying again with the absolute path.
+          const a = document.createElement('a');
+          a.href = grandSon.src;
+          sign = md5(a.pathname);
+      }
 
       img.onload = function () {
         let percent = ((img.height / img.width) * 100).toFixed(5);
@@ -54,6 +65,7 @@ function initLazyLoad() {
         let target = document.getElementById(`lht${sign}`)
 
         if (!target) return;
+
         target.parentNode.insertBefore(style, target);
         item.classList.remove("image-load");
         item.classList.add("image-loaded");


### PR DESCRIPTION
修复使用绝对路径的图片在post页面无法加载的问题

说明：假如我们在post使用绝对路径作为图片URL，例如 `/static/img.png`，在文章加载时html里面使用 `/static/img.png`计算md5，在 `loadAnimation` 函数会使用完整的URL( `grandSon.src`)进行计算，例如 `https://example.com/static/img.png`，从而导致md5不一致无法找到相应图片元素。

这个修复试图从 `grandSon.src`获取相对路径重新计算一遍md5。这是个临时方案，建议从源头保证 `loadAnimation`使用的地址与源头保持一致，但是不知道这样做会不会引起其它的问题。