### PR TITLE
feat(style): Add support for `<blockquote>` tag

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7365,3 +7365,26 @@ ul>li, ol>li {
 code {
   margin: 0px 0.25em;
 }
+
+blockquote {
+  background: #f9f9f9;
+  border-left: 10px solid #ccc;
+  margin: 1.5em 10px;
+  padding: 0.5em 10px;
+  quotes: "\201C""\201D""\2018""\2019";
+  max-width: 625px;
+  margin: auto;
+}
+
+blockquote:before {
+  color: #ccc;
+  content: open-quote;
+  font-size: 4em;
+  line-height: 0.1em;
+  margin-right: 0.25em;
+  vertical-align: -0.4em;
+}
+
+blockquote p {
+  display: inline;
+}


### PR DESCRIPTION
个人需求所致，同时也在issue区看到了 austin2035/astro-air-blog#15

为网站中的`<blockquote>`标签添加了css支持，其对应即是Markdown中的区块引用`>`
> 修改样式代码前后对比如下（以我的博客为例）  
> 修改前：  
> ![image](https://user-images.githubusercontent.com/90099234/226104361-1f1ff83a-65f6-435a-9deb-557ecdcfffc7.png)  
> 修改后：  
> ![image](https://user-images.githubusercontent.com/90099234/226104344-772ec13c-acbe-41c0-9f7f-a7a44cedf9fb.png)
