### PR TITLE
#20 Add sitemap for better SEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import { visit } from 'unist-util-visit'
 import md5 from 'md5';
+import sitemap from '@astrojs/sitemap';
 
 import { SITE_URL } from './src/consts';
 
@@ -171,4 +172,5 @@ export default defineConfig({
     rehypePlugins: pipeline(),
     syntaxHighlight: 'prism',
   },
+  integrations: [sitemap()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@astrojs/rss": "^2.1.1",
+				"@astrojs/sitemap": "^1.2.1",
 				"astro": "^2.0.11",
 				"md5": "^2.3.0",
 				"rehype": "^12.0.1",
@@ -94,6 +95,15 @@
 			"dependencies": {
 				"fast-xml-parser": "^4.0.8",
 				"kleur": "^4.1.5"
+			}
+		},
+		"node_modules/@astrojs/sitemap": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.1.tgz",
+			"integrity": "sha512-nlKP1qc1ENZ61w+ep5RdsObjYWso4QdLGC5WyzssnKkgVDijHT61s/tHFfBWHhxqdjcw4x1V1um/eSQZPDTR3Q==",
+			"dependencies": {
+				"sitemap": "^7.1.1",
+				"zod": "^3.17.3"
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
@@ -633,6 +643,11 @@
 				"@types/unist": "*"
 			}
 		},
+		"node_modules/@types/node": {
+			"version": "17.0.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+			"integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+		},
 		"node_modules/@types/parse5": {
 			"version": "6.0.3",
 			"license": "MIT"
@@ -640,6 +655,14 @@
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"license": "MIT"
+		},
+		"node_modules/@types/sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.6",
@@ -737,6 +760,11 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
 		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
@@ -3477,6 +3505,11 @@
 				"suf-log": "^2.5.3"
 			}
 		},
+		"node_modules/sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"node_modules/section-matter": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -3556,6 +3589,24 @@
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"license": "MIT"
+		},
+		"node_modules/sitemap": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
+			"integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+			"dependencies": {
+				"@types/node": "^17.0.5",
+				"@types/sax": "^1.2.1",
+				"arg": "^5.0.0",
+				"sax": "^1.2.4"
+			},
+			"bin": {
+				"sitemap": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=12.0.0",
+				"npm": ">=5.6.0"
+			}
 		},
 		"node_modules/slash": {
 			"version": "4.0.0",
@@ -4327,6 +4378,15 @@
 				"kleur": "^4.1.5"
 			}
 		},
+		"@astrojs/sitemap": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.1.tgz",
+			"integrity": "sha512-nlKP1qc1ENZ61w+ep5RdsObjYWso4QdLGC5WyzssnKkgVDijHT61s/tHFfBWHhxqdjcw4x1V1um/eSQZPDTR3Q==",
+			"requires": {
+				"sitemap": "^7.1.1",
+				"zod": "^3.17.3"
+			}
+		},
 		"@astrojs/telemetry": {
 			"version": "2.0.0",
 			"requires": {
@@ -4679,11 +4739,24 @@
 				"@types/unist": "*"
 			}
 		},
+		"@types/node": {
+			"version": "17.0.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+			"integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+		},
 		"@types/parse5": {
 			"version": "6.0.3"
 		},
 		"@types/resolve": {
 			"version": "1.20.2"
+		},
+		"@types/sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/unist": {
 			"version": "2.0.6"
@@ -4748,6 +4821,11 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
+		},
+		"arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -6208,6 +6286,11 @@
 				"suf-log": "^2.5.3"
 			}
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"section-matter": {
 			"version": "1.0.0",
 			"requires": {
@@ -6262,6 +6345,17 @@
 		},
 		"sisteransi": {
 			"version": "1.0.5"
+		},
+		"sitemap": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
+			"integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+			"requires": {
+				"@types/node": "^17.0.5",
+				"@types/sax": "^1.2.1",
+				"arg": "^5.0.0",
+				"sax": "^1.2.4"
+			}
 		},
 		"slash": {
 			"version": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@astrojs/rss": "^2.1.1",
+		"@astrojs/sitemap": "^1.2.1",
 		"astro": "^2.0.11",
 		"md5": "^2.3.0",
 		"rehype": "^12.0.1",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -31,3 +31,6 @@ const { pathname } = Astro.url;
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, `${SITE_URL}${pathname}`)} />
+
+<!-- Sitemap -->
+<link rel="sitemap" href="/sitemap-index.xml">


### PR DESCRIPTION
使用官方插件添加sitemap支持，主要的几处修改：
1. 添加 `sitemap` 插件相关的依赖
2. 在 `astro.config.mjs` 文件引入插件
3. 在 `BaseHead` 添加 `sitemap` 声明

注意：
该插件不支持实时预览，在 `num run build` 时生成 `sitemap-index.xml` 和 `sitemap-0.xml` 两个文件